### PR TITLE
Missing Preposition

### DIFF
--- a/ibm/readme.md
+++ b/ibm/readme.md
@@ -1,6 +1,6 @@
 # IBM
 
 - IBM is actively contributing to the Tekton project and using it as the foundation CI/CD technology for building cloud-native applications on Kubernetes in our public and hybrid clouds
-- We have invested UX and development resources to contribute the Tekton Dashboard to make Tekton easy to use for all developers
+- We have invested UX and development resources to contribute to the Tekton Dashboard to make Tekton easy to use for all developers
 - IBM strongly supports efforts to standardize CI/CD building blocks as a goal for the Tekton project as well as building a community to share experience and catalog best practices
 - We are deeply interested in ensuring the Tekton project quickly evolves to have stable APIs and appropriate release controls to let it be easily consumable


### PR DESCRIPTION
This commit adds a missing 'to' to the second sentence of
ibm/readme.md