### PR TITLE
chore: Delete cloudbees

### DIFF
--- a/cloudbees/readme.md
+++ b/cloudbees/readme.md
@@ -1,6 +1,0 @@
-# CloudBees
-
-- CloudBees sponsors [Jenkins X](https://github.com/jenkins-x/jx), which uses Tekton Pipelines.
-- Our engineers are active participants in the development of the various projects in the Tekton community.
-- We partnered with Google and a host of other companies to create the [Continuous Delivery Foundation](https://cd.foundation/).
-- We're excited to be at the forefront of k8s-native continuous delivery.


### PR DESCRIPTION
CloudBees are no longer sponsoring the development of Jenkins-X