### PR TITLE
Update CloudBees description as a friend of Tekton

### DIFF
--- a/cloudbees/readme.md
+++ b/cloudbees/readme.md
@@ -1,6 +1,5 @@
 # CloudBees
 
-- CloudBees sponsors [Jenkins X](https://github.com/jenkins-x/jx), which uses Tekton Pipelines.
-- Our engineers are active participants in the development of the various projects in the Tekton community.
+- CloudBees uses Tekton in its [cloud native DevSecOps platform](https://www.cloudbees.com/products/saas-platform)
 - We partnered with Google and a host of other companies to create the [Continuous Delivery Foundation](https://cd.foundation/).
 - We're excited to be at the forefront of k8s-native continuous delivery.


### PR DESCRIPTION
CloudBees is no longer actively sponsoring Jenkins X other than through its membership in the Continuous Delivery Foundation.

CloudBees uses Tekton in the DevSecOps platform that it just released at https://www.cloudbees.com/products/saas-platform

Original PR: https://github.com/tektoncd/friends/pull/38